### PR TITLE
Event correlator

### DIFF
--- a/dynamix/correlator/common.py
+++ b/dynamix/correlator/common.py
@@ -151,12 +151,12 @@ class OpenclCorrelator(OpenclProcessing):
             self.extra_options.update(extra_options)
 
     def _allocate_memory(self):
-        self.d_output = parray.zeros(
-            self.queue,
-            self.output_shape,
-            self.output_dtype
-        )
-        self.d_norm_mask = parray.to_device(self.queue, self.weights)
+        # self.d_output = parray.zeros(
+        #     self.queue,
+        #     self.output_shape,
+        #     self.output_dtype
+        # )
+        # self.d_norm_mask = parray.to_device(self.queue, self.weights)
         if self.qmask is not None:
             self.d_qmask = parray.to_device(self.queue, self.qmask)
 

--- a/dynamix/correlator/common.py
+++ b/dynamix/correlator/common.py
@@ -32,8 +32,9 @@ class OpenclCorrelator(OpenclProcessing):
         Parameters
         -----------
 
-        shape: tuple
-            Shape of each XPCS frame.
+        shape: tuple or int
+            Shape of each XPCS frame. If shape is an integer, the frames are
+            assumed to be square.
         nframes: int
             Number of frames
         qmask: numpy.ndarray, optional

--- a/dynamix/correlator/common.py
+++ b/dynamix/correlator/common.py
@@ -59,7 +59,8 @@ class BaseCorrelator(object):
             self.scale_factors = {1: s}
             return
         if scale_factor is not None:
-            assert np.iterable(scale_factor)
+            if not(np.iterable(scale_factor)):
+                scale_factor = [scale_factor]
             assert len(scale_factor) == self.n_bins
             if isinstance(scale_factor, dict):
                 self.scale_factors = scale_factor
@@ -176,7 +177,8 @@ class OpenclCorrelator(BaseCorrelator, OpenclProcessing):
         for arr_name, array in arrays.items():
             my_array_name = "d_" + arr_name
             my_array = getattr(self, my_array_name)
-            assert my_array.shape == array.shape
+            assert my_array.shape == array.shape, "%s should have shape %s, got %s" % (my_array_name, str(my_array.shape), str(array.shape))
+
             assert my_array.dtype == array.dtype
             if isinstance(array, np.ndarray):
                 my_array.set(array)

--- a/dynamix/correlator/event.py
+++ b/dynamix/correlator/event.py
@@ -76,7 +76,9 @@ class EventCorrelator(OpenclCorrelator):
 
 
     def _allocate_events_arrays(self, is_reallocating=False):
-        tot_nnz = self._events_count or self.max_events_count * np.prod(self.shape)
+        if self._events_count is None:
+            self._events_count = self.max_events_count * np.prod(self.shape)
+        tot_nnz = self._events_count
 
         self.d_vol_times = parray.zeros(self.queue, tot_nnz, dtype=np.int32)
         self.d_vol_data = parray.zeros(self.queue, tot_nnz, dtype=self.dtype)

--- a/dynamix/correlator/event.py
+++ b/dynamix/correlator/event.py
@@ -72,8 +72,8 @@ class EventCorrelator(OpenclCorrelator):
                 "-DSCALE_FACTOR=%f" % self.scale_factors[1], # TODO multi-bin
             ]
         )
-        self.correlation_kernel = self.kernels.get_kernel("event_correlator_oneQ") # TODO tune
-        self.normalization_kernel = self.kernels.get_kernel("normalize_correlation_oneQ") # TODO tune
+        self.correlation_kernel = self.kernels.get_kernel("event_correlator")
+        self.normalization_kernel = self.kernels.get_kernel("normalize_correlation_oneQ")
 
         self.grid = self.shape[::-1]
         self.wg = None # tune ?

--- a/dynamix/correlator/event.py
+++ b/dynamix/correlator/event.py
@@ -10,23 +10,40 @@ class EventCorrelator(OpenclCorrelator):
 
 
     def __init__(
-        self, shape, nframes, max_events_count=10,
+        self, shape, nframes, total_events_count, allow_reallocate=True,
         dtype="f", bins=0, weights=None, extra_options={},
         ctx=None, devicetype="all", platformid=None, deviceid=None,
         block_size=None, memory=None, profile=False
     ):
         """
-        TODO docstring
+        Initialize an EventCorrelator instance.
+
+        Parameters
+        -----------
+        Please refer to the documentation of dynamix.correlator.common.OpenclCorrelator
+
+        Specific parameters
+        --------------------
+        max_events_count: int
+            Expected number of events (non-zero values) in all the frames.
+            axis. If `frames_stack` is a numpy.ndarray of shape
+            `(n_frames, n_y, n_x)`, then `total_events_count` can be computed as
+
+            ```python
+            (frames_stack > 0).sum()
+            ```
         """
         super().__init__(
-            shape, nframes, dtype=dtype, bins=bins, weights=weights, extra_options=extra_options,
+            shape, nframes, dtype=dtype, bins=bins, weights=weights,
+            extra_options=extra_options,
             ctx=ctx, devicetype=devicetype, platformid=platformid,
             deviceid=deviceid, block_size=block_size, memory=memory,
             profile=profile
         )
-        self.max_events_count = max_events_count
+        self._events_count = total_events_count
+        self.allow_reallocate = allow_reallocate
+        self._allocate_events_arrays()
         self._setup_kernels()
-        self._allocate_event_arrays()
 
 
     def _setup_kernels(self):
@@ -41,31 +58,46 @@ class EventCorrelator(OpenclCorrelator):
                 "-DSCALE_FACTOR=%f" % (1./(np.prod(self.shape))),
             ]
         )
-        self.correlation_kernel = self.kernels.get_kernel("event_correlator_oneQ") # TODO tune
+        self.correlation_kernel = self.kernels.get_kernel("event_correlator_oneQ_simple") # TODO tune
         self.normalization_kernel = self.kernels.get_kernel("normalize_correlation_oneQ") # TODO tune
 
         self.grid = self.shape[::-1]
         self.wg = None # tune ?
 
 
-    def _allocate_event_arrays(self):
-        vol_shape = self.shape + (self.max_events_count, )
-        self.d_vol_times = parray.zeros(self.queue, vol_shape, dtype=np.int32) # tune "times" dtype ?
-        self.d_vol_data = parray.zeros(self.queue, vol_shape, dtype=self.dtype)
-        self.d_ctr = parray.zeros(self.queue, self.shape, dtype=np.int32) # uint ?
-        self.d_res_int = parray.zeros(self.queue, self.nframes, dtype=np.int32)
-        self._old_d_vol_times = None
-        self._old_d_vol_data = None
-        self._old_d_ctr = None
-        self.d_sums = parray.zeros(self.queue, self.nframes, np.uint32)
-        self.d_res = parray.zeros(self.queue, self.nframes, np.float32)
+    def _allocate_events_arrays(self, is_reallocating=False):
+        tot_nnz = self._events_count
+
+        self.d_vol_times = parray.zeros(self.queue, tot_nnz, dtype=np.int32)
+        self.d_vol_data = parray.zeros(self.queue, tot_nnz, dtype=self.dtype)
+        self.d_offsets = parray.zeros(self.queue, np.prod(self.shape)+1, dtype=np.uint32)
+
+        if not(is_reallocating):
+            self.d_res_int = parray.zeros(self.queue, self.nframes, dtype=np.int32)
+            self.d_sums = parray.zeros(self.queue, self.nframes, np.uint32)
+            self.d_res = parray.zeros(self.queue, self.nframes, np.float32)
 
 
-    def correlate(self, vol_times, vol_data, ctr):
+    def _check_event_arrays(self, vol_times, vol_data, offsets):
+        for arr in [vol_times, vol_data, offsets]:
+            assert arr.ndim == 1
+        assert vol_times.size == vol_data.size
+        assert offsets.size == np.prod(self.shape) + 1
+        numels = vol_data.size
+        if numels > self._events_count:
+            if self.allow_reallocate:
+                self._events_count = numels
+                self._allocate_events_arrays(is_reallocating=True)
+            else:
+                raise ValueError("Too many events and allow_reallocate was set to False")
+
+
+    def correlate(self, vol_times, vol_data, offsets):
+        self._check_event_arrays(vol_times, vol_data, offsets)
         self._set_data({
             "vol_times": vol_times,
             "vol_data": vol_data,
-            "ctr": ctr
+            "offsets": offsets
         })
 
         evt = self.correlation_kernel(
@@ -74,7 +106,7 @@ class EventCorrelator(OpenclCorrelator):
             self.wg,
             self.d_vol_times.data,
             self.d_vol_data.data,
-            self.d_ctr.data,
+            self.d_offsets.data,
             self.d_res_int.data,
             self.d_sums.data,
             np.int32(self.nframes)
@@ -95,38 +127,75 @@ class EventCorrelator(OpenclCorrelator):
         self.profile_add(evt, "Normalization")
 
         self._reset_arrays(["d_vol_times", "d_vol_data", "d_ctr"])
-        
+
         return self.d_res.get()
 
 
-    def build_events_volume(self, frames):
+
+
+    @staticmethod
+    def build_events_structure(frames):
         """
-        Helper function to build a
-        from a stack of (uncompressed) frames.
+        Helper function to build the events data structure from a stack of frames.
+        It returns a tuple (data, times, offsets).
         """
-        max_events = self.max_events_count
-        dtype = self.dtype
+        assert frames.ndim == 3
+        framesT = np.moveaxis(frames, 0, -1)
+        times = np.arange(frames.shape[0], dtype=np.int32)
+        nnz_indices = np.where(framesT > 0)
 
-        frame_shape = frames.shape[1:]
-        n_frames = frames.shape[0]
+        res_data = framesT[nnz_indices]
+        res_times = times[nnz_indices[-1]]
 
-        vol_shape = frame_shape + (max_events, )
-        volume_times = np.zeros(vol_shape, dtype=np.int32)
-        volume_data = np.zeros(vol_shape, dtype=dtype)
-        ctr = np.zeros(frame_shape, dtype=np.int32)
+        offsets = np.unique(np.cumsum((framesT > 0).sum(axis=-1).ravel()))
+        res_offsets = np.ascontiguousarray(offsets, dtype=np.uint32)
 
-        rows, cols = np.indices(frame_shape)
+        return res_data, res_times, res_offsets
 
-        for i in range(n_frames):
-            frame = frames[i]
-            mask = frame > 0
 
-            R = rows[mask]
-            C = cols[mask]
-            depth_pos = ctr[R, C]
-            volume_times[R, C, depth_pos] = i
-            volume_data[R, C, depth_pos] = frame[mask]
-            ctr[R, C] += 1
 
-        return volume_times, volume_data, ctr
 
+
+
+
+"""
+Let `frames` be a stack of `Nt` frames, each of them having `Nx * Ny` pixels.
+
+At each location `(x, y)` in the frame space, we can extract a 1D array
+of `Nt` elements (i.e `frames[:, y, x]`).
+In this array, many elements will be zero, so it is not useful to store them.
+
+The non-zero elements are compacted, along with their "time" index
+in the original frames volume (i.e their indices along axis 0 in the volume space).
+Schematically:
+[0 0 ...     0   p1  0 ...  0   p2 0 ... 0 p3 0 ...] # pixels values
+[0 1 ... (i1-1)  i1 .... (i2-1) i2 0 ... 0 i3 0 ...] # indices values
+gives once compacted:
+[p1 p2 p3 ...] # (nonzero) pixel values
+[i1 i2 i3 ...] # corresponding "time" locations
+
+This is done for each pixel location (x, y). Therefore, for each pixel in the
+frame space (there are Nx*Ny such pixels), we build two arrays E(x, y) and T(x, y)
+containing respectively the compacted non-zero elements, and their time indices.
+
+ -----------
+|      []   |  at location (x, y)   --> (E(x, y), T(x, y)) = ([p1, p2, ...], [t1, t2, ...])
+|           |
+|           |
+ -----------
+
+[ E(0, 0) | E(0, 1) | ... | E(x, y) | ... | E(Ny-1, Nx-1) ] # concatenated nonzero data values
+[ T(0, 0) | T(0, 1) | ... | T(x, y) | ... | T(Ny-1, Nx-1) ] # concatenated corresponding time indices
+
+In order to access the correct arrays E(x, y) and T(x, y) given a coordinate (x, y),
+we need some mapping. This is done by building an "offset" array "L":
+
+[L0 = 0   | L1      | ... | L(x, y) | ... ] # offsets
+[ E(0, 0) | E(0, 1) | ... | E(x, y) | ... | E(Ny-1, Nx-1) ] # concatenated nonzero data values
+
+The offset to access E(0, 0) is 0.
+The offset to access E(0, 1) is 0 + <number of non-zero pixels in E(0 0)>,
+and so on.
+
+
+"""

--- a/dynamix/correlator/test/test_event.py
+++ b/dynamix/correlator/test/test_event.py
@@ -1,0 +1,139 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2019-2019 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""tests for the event correlator.
+
+"""
+
+__authors__ = ["P. Paleo"]
+__license__ = "MIT"
+__date__ = "04/09/2019"
+
+
+from time import time
+import logging
+import unittest
+import numpy as np
+from dynamix.test.utils import XPCSDataset
+from dynamix.correlator.event import EventCorrelator, FramesCompressor
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+
+class TestEventDataStructure(unittest.TestCase):
+
+    def setUp(self):
+        logger.debug("Loading data")
+        self.dataset = XPCSDataset("andor_1024_3k")
+        self.shape = self.dataset.dataset_desc.frame_shape
+        self.nframes = self.dataset.dataset_desc.nframes
+        self.compressor = FramesCompressor(self.shape, self.nframes, 330, np.int8)
+
+    def tearDown(self):
+        pass
+
+    def compute_reference_datastructure(self):
+        logger.debug("Computing reference data compaction to events")
+        return self.compressor.compress_all_stack(self.dataset.data)
+
+
+    def test_progressive_compression(self):
+        # Simulate progressive acquisition + compaction of frames
+        logger.debug("Computing progressive data compaction")
+        for frame in self.dataset.data:
+            self.compressor.process_frame(frame)
+        # Compare with reference implementation (compact all frames in a single pass)
+        ref_data, ref_times, ref_offsets = self.compute_reference_datastructure()
+        data, times, offsets = self.compressor.get_compacted_events()
+
+        self.assertTrue(np.allclose(data, ref_data))
+        self.assertTrue(np.allclose(times, ref_times))
+        self.assertTrue(np.allclose(offsets, ref_offsets))
+
+
+class TestEvent(unittest.TestCase):
+
+    ref = None
+
+    def setUp(self):
+        logger.debug("Loading data")
+        self.dataset = XPCSDataset("andor_1024_10k")
+        self.shape = self.dataset.dataset_desc.frame_shape
+        self.nframes = self.dataset.dataset_desc.nframes
+        self.ref = self.dataset.result
+        self.tol = 5e-3
+
+    def tearDown(self):
+        pass
+
+
+    def compare(self, res, method_name):
+        errors = res[:, 1:] - self.ref
+        errors_max = np.max(np.abs(errors), axis=1)
+
+        for bin_idx in range(errors_max.shape[0]):
+            self.assertLess(
+                errors_max[bin_idx], self.tol,
+                "%s: something wrong in bin index %d" % (method_name, bin_idx)
+            )
+
+    def test_event_correlator(self):
+        # Init correlator
+        self.correlator = EventCorrelator(
+            self.shape,
+            self.nframes,
+            dtype=self.dataset.dataset_desc.dtype,
+            max_events_count=330,
+            scale_factor=1025171, # number of pixels actually used
+            profile=True
+        )
+        # Build events data structure
+        vol_data, vol_times, offsets = self.correlator.build_events_structure(
+            self.dataset.data
+        )
+        # Correlate
+        t0 = time()
+        res = self.correlator.correlate(
+            vol_times,
+            vol_data,
+            offsets
+        )
+        logger.info("OpenCL dense correlator took %.1f ms" % ((time() - t0)*1e3))
+        self.compare(res, "OpenCL dense correlator")
+
+
+
+def suite():
+    testsuite = unittest.TestSuite()
+    testsuite.addTest(
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestEventDataStructure)
+        # unittest.defaultTestLoader.loadTestsFromTestCase(TestEvent)
+    )
+    return testsuite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest="suite")
+

--- a/dynamix/resources/opencl/evtcorrelator.cl
+++ b/dynamix/resources/opencl/evtcorrelator.cl
@@ -72,6 +72,6 @@ kernel void normalize_correlation(
         corr += (my_sum[t] * my_sum[t - tau]);
     }
     corr /= scale_factors[bin_idx]; // passing 1/scale_factor in preprocessor is not numerically accurate
-    res[bin_idx + Nt + tau] = res_int[bin_idx*Nt + tau] / corr;
+    res[bin_idx * Nt + tau] = res_int[bin_idx*Nt + tau] / corr;
 }
 

--- a/dynamix/resources/opencl/evtcorrelator.cl
+++ b/dynamix/resources/opencl/evtcorrelator.cl
@@ -1,4 +1,5 @@
-// Launched with (image_width, image_width) grid of threads.
+// Launched with (image_width, image_height) grid of threads.
+// One thread handle one line of events, so threads are indexes by frame pixel indices.
 kernel void event_correlator_oneQ(
     const global int* vol_times_array,
     const global DTYPE* vol_data_array,

--- a/dynamix/resources/opencl/evtcorrelator.cl
+++ b/dynamix/resources/opencl/evtcorrelator.cl
@@ -21,11 +21,11 @@ kernel void event_correlator_oneQ(
     global DTYPE* vol_data = vol_data_array + offset;
 
     // Fetch vol_XXX[y, x, :] in fast memory
-    int times[MAX_EVT_COUNT];
-    DTYPE data[MAX_EVT_COUNT];
+    int times[MAX_EVT_COUNT] = {0};
+    DTYPE data[MAX_EVT_COUNT] = {0};
     for (int i = 0; i < n_events; i++) {
-        times[i] = vol_times[pos*MAX_EVT_COUNT+i];
-        data[i] = vol_data[pos*MAX_EVT_COUNT+i];
+        times[i] = vol_times[i];
+        data[i] = vol_data[i];
     }
 
     // Compute r(p, t, t-tau)
@@ -42,49 +42,6 @@ kernel void event_correlator_oneQ(
 
 
 
-
-
-
-// "Event correlator"
-// One thread : r(p, (t, t-tau)) -> atomic_add
-
-kernel void event_correlator_oneQ_simple(
-    const global int* vol_times,
-    const global DTYPE* vol_data,
-    const global int* ctr,
-    global int* res_tau,
-    global uint* sums,
-    int image_height
-) {
-    uint x = get_global_id(0);
-    uint y = get_global_id(1);
-
-    if ((x >= IMAGE_WIDTH) || (y >= image_height)) return;
-
-    uint pos = y*IMAGE_WIDTH + x;
-    int n_events = ctr[pos];
-    if (n_events == 0) return;
-
-
-    // Fetch vol_XXX[y, x, :] in fast memory
-    // TODO investigate registers usage
-    int times[MAX_EVT_COUNT];
-    DTYPE data[MAX_EVT_COUNT];
-    for (int i = 0; i < n_events; i++) {
-        times[i] = vol_times[pos*MAX_EVT_COUNT+i];
-        data[i] = vol_data[pos*MAX_EVT_COUNT+i];
-    }
-
-    // Compute r(p, t, t-tau)
-    DTYPE sum = 0;
-    for (int i_tau = 0; i_tau < n_events; i_tau++) {
-        atomic_add(sums + times[i_tau], data[i_tau]);
-        for (int i_t = i_tau; i_t < n_events; i_t++) {
-            int tau = times[i_t] - times[i_t - i_tau];
-            atomic_add(res_tau + tau, data[i_t] * data[i_t - i_tau]);
-        }
-    }
-}
 
 
 #ifndef SCALE_FACTOR
@@ -104,8 +61,9 @@ kernel void normalize_correlation_oneQ(
     if (tau >= Nt) return;
     float s = 0.0f;
     for (int t = tau; t < Nt; t++) {
-        s += (sums[t] * sums[t - tau]) * SCALE_FACTOR;
+        s += (sums[t] * sums[t - tau]);
     }
+    s /= SCALE_FACTOR;
     res[tau] = res_int[tau] / s;
 }
 

--- a/dynamix/resources/opencl/evtcorrelator.cl
+++ b/dynamix/resources/opencl/evtcorrelator.cl
@@ -1,8 +1,54 @@
+// Launched with (image_width, image_width) grid of threads.
+kernel void event_correlator_oneQ(
+    const global int* vol_times_array,
+    const global DTYPE* vol_data_array,
+    const global uint* offsets,
+    global int* res_tau,
+    global uint* sums,
+    int image_height
+) {
+    uint x = get_global_id(0);
+    uint y = get_global_id(1);
+
+    if ((x >= IMAGE_WIDTH) || (y >= image_height)) return;
+
+    uint pos = y*IMAGE_WIDTH + x;
+    uint offset = offsets[pos];
+    int n_events = offsets[pos+1] - offset;
+    if (n_events == 0) return;
+
+    global int* vol_times = vol_times_array + offset;
+    global DTYPE* vol_data = vol_data_array + offset;
+
+    // Fetch vol_XXX[y, x, :] in fast memory
+    int times[MAX_EVT_COUNT];
+    DTYPE data[MAX_EVT_COUNT];
+    for (int i = 0; i < n_events; i++) {
+        times[i] = vol_times[pos*MAX_EVT_COUNT+i];
+        data[i] = vol_data[pos*MAX_EVT_COUNT+i];
+    }
+
+    // Compute r(p, t, t-tau)
+    DTYPE sum = 0;
+    for (int i_tau = 0; i_tau < n_events; i_tau++) {
+        atomic_add(sums + times[i_tau], data[i_tau]);
+        for (int i_t = i_tau; i_t < n_events; i_t++) {
+            int tau = times[i_t] - times[i_t - i_tau];
+            atomic_add(res_tau + tau, data[i_t] * data[i_t - i_tau]);
+        }
+    }
+}
+
+
+
+
+
+
+
 // "Event correlator"
 // One thread : r(p, (t, t-tau)) -> atomic_add
 
-
-kernel void event_correlator_oneQ(
+kernel void event_correlator_oneQ_simple(
     const global int* vol_times,
     const global DTYPE* vol_data,
     const global int* ctr,

--- a/dynamix/test/utils.py
+++ b/dynamix/test/utils.py
@@ -73,7 +73,7 @@ dataset_eiger_20k = DatasetDescription(
     bins=None,
 )
 
-dataset_al_600 =DatasetDescription(
+dataset_al_600 = DatasetDescription(
     name="Al_512_600",
     data="Al_600.npz",
     result="unknown.npz",
@@ -85,7 +85,7 @@ dataset_al_600 =DatasetDescription(
     frame_shape=(512, 512),
     dtype=np.uint32,
     bins=None,
-) 
+)
 
 def get_datasets():
     datasets = [dataset_andor_10k, dataset_andor_3k, dataset_eiger_10k, dataset_eiger_20k, dataset_al_600]

--- a/dynamix/test/utils.py
+++ b/dynamix/test/utils.py
@@ -31,7 +31,7 @@ dataset_andor_10k = DatasetDescription(
 )
 
 dataset_andor_3k = DatasetDescription(
-    name="andor_1024_10k",
+    name="andor_1024_3k",
     data="Fe79_Andor_3000.npz",
     result="wcf_Fe79_ramp1_240C_down_1_3000_raw.npz",
     description="""


### PR DESCRIPTION
This PR brings an OpenCL implementation of the "Event Correlator" to compute the correlation function of sparse XPCS data. The name "Event Correlator" comes from the legacy XPCS software.

The principle is to build a data structure well-suited for parallelism and GPU fast memory. A helper class `FramesCompressor` helps to build this data structure from progressively acquired data.
The principle is really simple : keep nonzero entries and put them in a certain shape.

```python
from dynamix.correlator.event import EventCorrelator, FramesCompressor
from dynamix.test.utils import XPCSDataset
X = XPCSDataset("andor_1024_10k")
max_nnz = 330 # we dont expect more than 330 hits per pixel location
F = FramesCompressor(X.data.shape[1:], X.data.shape[0], max_nnz)

# Frames are compacted as they come, so the data structure is progressively built
for frame in X.data:
    F.process_frame(frame)

# Get the final data structure
events, times, offsets = F.get_compacted_events()

E = EventCorrelator(X.data.shape[1:], X.data.shape[0], F.max_nnz, dtype=X.data.dtype, total_events_count=events.size, scale_factor=1025171)
res = E.correlate(times, events, offsets) # all is done with OpenCL here
```

The event correlator supports multi-bins data, but data type other than integer is not supported yet (it can be with minor additions like an OpenCL float32 `atomic_add()`).