### PR TITLE
Dense correlator

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 `dynamix` is a Python module for X-ray photon correlation spectroscopy (XPCS). It primarily aims at offering fast correlation function computation with OpenCL/CUDA implementations.
 
-**Work in progress:** please keep in mind that this is work in progress. The API might change 
+**Work in progress:** please keep in mind that this is work in progress. The API might change at this early stage of the project.
 
 `dynamix` provides classes named **correlators** to compute the XPCS correlation function `g2` defined by
 ![g2](https://latex.codecogs.com/gif.latex?g_2(q,&space;\tau)&space;=&space;\dfrac{&space;\langle&space;\langle&space;I(t,\,&space;p)&space;I(t&space;&plus;&space;\tau,\,&space;p)&space;\rangle_p&space;\rangle_t&space;}&space;{&space;\langle&space;\langle&space;I(t,\,&space;p)&space;\rangle_p&space;\langle&space;I(t&space;&plus;&space;\tau,\,&space;p)&space;\rangle_p&space;\rangle_t&space;})
@@ -73,7 +73,6 @@ Then use a correlator:
 
 ```python
 from dynamix.correlator.dense import MatMulCorrelator
-
 correlator = MatMulCorrelator(shape, nframes, mask=dataset.qmask)
 result = correlator.correlate(data)
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ All correlators compute the function `g_2`, although through different means.
 
 ## Installation
 
-### Python dependencies
+### Python dependencies
 
 dynamix depends on the following python packages:
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,88 @@
 # dynamix
-XPCS project
+
+
+## About
+
+`dynamix` is a Python module for X-ray photon correlation spectroscopy (XPCS). It primarily aims at offering fast correlation function computation with OpenCL/CUDA implementations.
+
+**Work in progress:** please keep in mind that this is work in progress. The API might change 
+
+`dynamix` provides classes named **correlators** to compute the XPCS correlation function `g2` defined by
+![g2](https://latex.codecogs.com/gif.latex?g_2(q,&space;\tau)&space;=&space;\dfrac{&space;\langle&space;\langle&space;I(t,\,&space;p)&space;I(t&space;&plus;&space;\tau,\,&space;p)&space;\rangle_p&space;\rangle_t&space;}&space;{&space;\langle&space;\langle&space;I(t,\,&space;p)&space;\rangle_p&space;\langle&space;I(t&space;&plus;&space;\tau,\,&space;p)&space;\rangle_p&space;\rangle_t&space;})
+
+where `< . >_p` denotes averaging pixels belonging to the current bin (scattering vector), and `< . >_t` denotes time averaging.
+
+All correlators compute the function `g_2`, although through different means.
+
+
+## Installation
+
+### Python dependencies
+
+dynamix depends on the following python packages:
+
+  - numpy
+  - pyopencl
+  - [silx](https://github.com/silx-kit/silx)
+
+Optionally:
+
+- pyfftw
+- scikit-cuda
+
+These modules should be automatically installed when installing `dynamix`.
+
+### System dependencies
+
+dynamix needs:
+
+- An implementation of OpenCL (>= 1.2)
+- Optionally, CUDA and CUFFT
+- Optionally, FFTW library and header files
+
+### Releases versions
+
+To install the current release from [pypi](https://pypi.org/project/dynamix/):
+
+```bash
+pip install [--user] dynamix
+```
+
+### Development versions
+
+To install the current development version:
+
+```bas
+pip instal [--user] git+https://github.com/silx-kit/dynamix
+```
+
+## Usage
+
+First load a dataset. `dynamix` provides some datasets acquired at ESRF ID10.
+
+```python
+from dynamix.test.utils import XPCSDataset
+dataset = XPCSDataset("eiger_514_10k")
+data = dataset.data
+shape = dataset.dataset_desc.frame_shape
+nframes = dataset.dataset_desc.nframes
+print(dataset.dataset_desc.description)
+```
+
+Then use a correlator:
+
+```python
+from dynamix.correlator.dense import MatMulCorrelator
+
+correlator = MatMulCorrelator(shape, nframes, mask=dataset.qmask)
+result = correlator.correlate(data)
+```
+
+This is the basic (and slowest) correlator. Please refer to the documentation to use other backends.
+
+## Question ? Bug ?
+
+Please [open an issue](https://github.com/silx-kit/dynamix/issues) on the project page to report bugs or ask questions.
+
+
+

--- a/dynamix/correlator/common.py
+++ b/dynamix/correlator/common.py
@@ -151,12 +151,12 @@ class OpenclCorrelator(OpenclProcessing):
             self.extra_options.update(extra_options)
 
     def _allocate_memory(self):
-        self.d_output = parray.zeros(
-            self.queue,
-            self.output_shape,
-            self.output_dtype
-        )
-        self.d_norm_mask = parray.to_device(self.queue, self.weights)
+        # self.d_output = parray.zeros(
+        #     self.queue,
+        #     self.output_shape,
+        #     self.output_dtype
+        # )
+        # self.d_norm_mask = parray.to_device(self.queue, self.weights)
         if self.qmask is not None:
             self.d_qmask = parray.to_device(self.queue, self.qmask)
 

--- a/dynamix/correlator/common.py
+++ b/dynamix/correlator/common.py
@@ -32,8 +32,9 @@ class OpenclCorrelator(OpenclProcessing):
         Parameters
         -----------
 
-        shape: tuple
-            Shape of each XPCS frame.
+        shape: tuple or int
+            Shape of each XPCS frame. If shape is an integer, the frames are
+            assumed to be square.
         nframes: int
             Number of frames
         qmask: numpy.ndarray, optional

--- a/dynamix/correlator/common.py
+++ b/dynamix/correlator/common.py
@@ -59,7 +59,8 @@ class BaseCorrelator(object):
             self.scale_factors = {1: s}
             return
         if scale_factor is not None:
-            assert np.iterable(scale_factor)
+            if not(np.iterable(scale_factor)):
+                scale_factor = [scale_factor]
             assert len(scale_factor) == self.n_bins
             if isinstance(scale_factor, dict):
                 self.scale_factors = scale_factor
@@ -176,7 +177,8 @@ class OpenclCorrelator(BaseCorrelator, OpenclProcessing):
         for arr_name, array in arrays.items():
             my_array_name = "d_" + arr_name
             my_array = getattr(self, my_array_name)
-            assert my_array.shape == array.shape
+            assert my_array.shape == array.shape, "%s should have shape %s, got %s" % (my_array_name, str(my_array.shape), str(array.shape))
+
             assert my_array.dtype == array.dtype
             if isinstance(array, np.ndarray):
                 my_array.set(array)

--- a/dynamix/correlator/cuda.py
+++ b/dynamix/correlator/cuda.py
@@ -1,0 +1,177 @@
+import numpy as np
+from ..utils import nextpow2, updiv, get_next_power
+from .dense import MatMulCorrelator, FFTCorrelator
+
+try:
+    from silx.math.fft.cufft import CUFFT
+    import pycuda.gpuarray as garray
+    from pycuda.compiler import SourceModule
+    from pycuda.driver import Memcpy2D, Memcpy3D
+except ImportError:
+    CUFFT = None
+try:
+    import skcuda.linalg as cublas
+    import skcuda.misc as skmisc
+except ImportError:
+    cublas = None
+
+
+class CublasMatMulCorrelator(MatMulCorrelator):
+
+    """
+    The CublasMatMulCorrelator is a CUDA-accelerated version of MatMulCorrelator.
+    """
+
+    def __init__(self, shape, nframes,
+                 qmask=None,
+                 scale_factor=None,
+                 extra_options={}):
+
+        """
+        Initialize a CUBLAS matrix multiplication correlator.
+        Please refer to the documentation of BaseCorrelator for the documentation
+        of each parameters.
+
+        Extra options
+        --------------
+        cublas_handle: int
+            If provided, use this cublas handle instead of creating a new one.
+        """
+        if cublas is None:
+            raise ImportError("scikit-cuda is needed to use this correlator")
+
+        super().__init__(
+            shape, nframes,
+            qmask=qmask, scale_factor=scale_factor, extra_options=extra_options
+        )
+        self._init_cublas()
+        self._compile_kernels()
+
+
+    def _init_cublas(self):
+        import pycuda.autoinit
+        if "cublas_handle" in self.extra_options:
+            handle = self.extra_options["cublas_handle"]
+        else:
+            handle = skmisc._global_cublas_handle
+            if handle is None:
+                cublas.init() # cublas handle + allocator
+                handle = skmisc._global_cublas_handle
+        self.cublas_handle = handle
+
+
+    def _compile_kernels(self):
+        mod = SourceModule(
+            """
+            // Extract the upper diagonals of a square (N, N) matrix.
+            __global__ void extract_upper_diags(float* matrix, float* diags, int N) {
+                int x = blockDim.x * blockIdx.x + threadIdx.x;
+                int y = blockDim.y * blockIdx.y + threadIdx.y;
+                if ((x >= N) || (y >= N) || (y > x)) return;
+                int pos = y*N+x;
+                int my_diag = x-y;
+                diags[my_diag * N + x] = matrix[pos];
+            }
+            """
+        )
+        self.extract_diags_kernel = mod.get_function("extract_upper_diags")
+        self._blocks = (32, 32, 1)
+        self._grid = (
+            updiv(self.nframes, self._blocks[0]),
+            updiv(self.nframes, self._blocks[1]),
+            1
+        )
+        self.d_diags = garray.zeros((self.nframes, self.nframes), dtype=np.float32)
+        self.d_sumdiags1 = garray.zeros(self.nframes, dtype=np.float32)
+        self.d_sumdiags2 = garray.zeros_like(self.d_sumdiags1)
+        self._kern_args = [
+            None,
+            self.d_diags,
+            np.int32(self.nframes),
+        ]
+
+
+    def sum_diagonals(self, d_arr, d_out):
+        self.d_diags.fill(0)
+        self._kern_args[0] = d_arr.gpudata
+        self.extract_diags_kernel(*self._kern_args, grid=self._grid, block=self._blocks)
+        skmisc.sum(self.d_diags, axis=1, out=d_out)
+
+
+    def _correlate_matmul_cublas(self, frames_flat, mask):
+        arr = np.ascontiguousarray(frames_flat[:, mask], dtype=np.float32)
+        npix = arr.shape[1]
+        # Pre-allocating memory for all bins might save a bit of time,
+        # but would take more memory
+        d_arr = garray.to_gpu(arr)
+        d_outer = cublas.dot(d_arr, d_arr, transb="T", handle=self.cublas_handle)
+        d_means = skmisc.mean(d_arr, axis=1, keepdims=True)
+        d_denom_mat = cublas.dot(d_means, d_means, transb="T", handle=self.cublas_handle)
+
+        self.sum_diagonals(d_outer, self.d_sumdiags1)
+        self.sum_diagonals(d_denom_mat, self.d_sumdiags2)
+        self.d_sumdiags1 /= self.d_sumdiags2
+        self.d_sumdiags1 /= npix
+
+        return self.d_sumdiags1.get()
+
+    def correlate(self, frames):
+        res = np.zeros((self.n_bins, self.nframes), dtype=np.float32)
+        frames_flat = frames.reshape((self.nframes, -1))
+
+        for i, bin_val in enumerate(self.bins):
+            mask = (self.qmask.ravel() == bin_val)
+            res[i] = self._correlate_matmul_cublas(frames_flat, mask)
+        return res
+
+
+
+class CUFFTCorrelator(FFTCorrelator):
+    def __init__(self, shape, nframes,
+                 qmask=None,
+                 weights=None,
+                 scale_factor=None,
+                 precompute_fft_plans=False,
+                 extra_options={}):
+        super().__init__(
+            shape, nframes, qmask=qmask,
+            weights=weights, scale_factor=scale_factor,
+            precompute_fft_plans=precompute_fft_plans, extra_options=extra_options
+        )
+        if CUFFT is None:
+            raise ImportError("pycuda and scikit-cuda need to be installed")
+        self.d_sums = garray.zeros(self.Nf, np.float32)
+        if skmisc._global_cublas_handle is None:
+            cublas.init()
+
+    def _create_fft_plan(self, npix):
+        return CUFFT(shape=(npix, self.Nf), dtype=np.float32,  axes=(-1,))
+
+    def _correlate_fft(self, frames_flat, cufft_plan):
+        npix = frames_flat.shape[1]
+
+        cufft_plan.data_in.fill(0)
+        d_in = cufft_plan.data_in
+        f_out1 = cufft_plan.data_out
+        f_out2 = garray.zeros_like(cufft_plan.data_out)
+
+        cufft_plan.data_in[:, :self.nframes] = frames_flat.T.astype("f")
+
+        f_out1 = cufft_plan.fft(d_in, output=f_out1)
+        cufft_plan.data_in.fill(0)
+        cufft_plan.data_in[:, :self.nframes] = frames_flat.T[:, ::-1].astype("f")
+
+        f_out2 = cufft_plan.fft(d_in, output=f_out2)
+        f_out1 *= f_out2
+        num = cufft_plan.ifft(f_out1, output=cufft_plan.data_in)
+        skmisc.sum(num, axis=0, out=self.d_sums)
+
+        num = self.d_sums.get()[self.nframes-1:self.nframes-1 + self.nframes]
+        # gpu ?
+        sums = frames_flat.sum(axis=1)
+        denom = np.correlate(sums, sums, "full")[sums.size-1:] / npix # TODO GPU, it takes 2/3 of the time
+        #
+
+        res = num/denom
+        return res
+

--- a/dynamix/correlator/dense.py
+++ b/dynamix/correlator/dense.py
@@ -254,6 +254,11 @@ class DenseCorrelator(OpenclCorrelator):
             self.output_shape,
             self.output_dtype,
         )
+        self.d_output = parray.zeros(
+            self.queue,
+            (self.n_bins, self.nframes),
+            np.float32
+        )
 
 
     def _normalize_sums(self):
@@ -280,7 +285,6 @@ class DenseCorrelator(OpenclCorrelator):
             self.wg,
             self.d_frames.data,
             self.d_qmask.data,
-            self.d_norm_mask.data,
             self.d_sums_f.data,
             self.d_output.data,
             np.int32(self.shape[0]),

--- a/dynamix/correlator/event.py
+++ b/dynamix/correlator/event.py
@@ -76,7 +76,9 @@ class EventCorrelator(OpenclCorrelator):
 
 
     def _allocate_events_arrays(self, is_reallocating=False):
-        tot_nnz = self._events_count or self.max_events_count * np.prod(self.shape)
+        if self._events_count is None:
+            self._events_count = self.max_events_count * np.prod(self.shape)
+        tot_nnz = self._events_count
 
         self.d_vol_times = parray.zeros(self.queue, tot_nnz, dtype=np.int32)
         self.d_vol_data = parray.zeros(self.queue, tot_nnz, dtype=self.dtype)

--- a/dynamix/correlator/event.py
+++ b/dynamix/correlator/event.py
@@ -72,8 +72,8 @@ class EventCorrelator(OpenclCorrelator):
                 "-DSCALE_FACTOR=%f" % self.scale_factors[1], # TODO multi-bin
             ]
         )
-        self.correlation_kernel = self.kernels.get_kernel("event_correlator_oneQ") # TODO tune
-        self.normalization_kernel = self.kernels.get_kernel("normalize_correlation_oneQ") # TODO tune
+        self.correlation_kernel = self.kernels.get_kernel("event_correlator")
+        self.normalization_kernel = self.kernels.get_kernel("normalize_correlation_oneQ")
 
         self.grid = self.shape[::-1]
         self.wg = None # tune ?

--- a/dynamix/correlator/event.py
+++ b/dynamix/correlator/event.py
@@ -10,23 +10,40 @@ class EventCorrelator(OpenclCorrelator):
 
 
     def __init__(
-        self, shape, nframes, max_events_count=10,
+        self, shape, nframes, total_events_count, allow_reallocate=True,
         dtype="f", bins=0, weights=None, extra_options={},
         ctx=None, devicetype="all", platformid=None, deviceid=None,
         block_size=None, memory=None, profile=False
     ):
         """
-        TODO docstring
+        Initialize an EventCorrelator instance.
+
+        Parameters
+        -----------
+        Please refer to the documentation of dynamix.correlator.common.OpenclCorrelator
+
+        Specific parameters
+        --------------------
+        max_events_count: int
+            Expected number of events (non-zero values) in all the frames.
+            axis. If `frames_stack` is a numpy.ndarray of shape
+            `(n_frames, n_y, n_x)`, then `total_events_count` can be computed as
+
+            ```python
+            (frames_stack > 0).sum()
+            ```
         """
         super().__init__(
-            shape, nframes, dtype=dtype, bins=bins, weights=weights, extra_options=extra_options,
+            shape, nframes, dtype=dtype, bins=bins, weights=weights,
+            extra_options=extra_options,
             ctx=ctx, devicetype=devicetype, platformid=platformid,
             deviceid=deviceid, block_size=block_size, memory=memory,
             profile=profile
         )
-        self.max_events_count = max_events_count
+        self._events_count = total_events_count
+        self.allow_reallocate = allow_reallocate
+        self._allocate_events_arrays()
         self._setup_kernels()
-        self._allocate_event_arrays()
 
 
     def _setup_kernels(self):
@@ -41,31 +58,46 @@ class EventCorrelator(OpenclCorrelator):
                 "-DSCALE_FACTOR=%f" % (1./(np.prod(self.shape))),
             ]
         )
-        self.correlation_kernel = self.kernels.get_kernel("event_correlator_oneQ") # TODO tune
+        self.correlation_kernel = self.kernels.get_kernel("event_correlator_oneQ_simple") # TODO tune
         self.normalization_kernel = self.kernels.get_kernel("normalize_correlation_oneQ") # TODO tune
 
         self.grid = self.shape[::-1]
         self.wg = None # tune ?
 
 
-    def _allocate_event_arrays(self):
-        vol_shape = self.shape + (self.max_events_count, )
-        self.d_vol_times = parray.zeros(self.queue, vol_shape, dtype=np.int32) # tune "times" dtype ?
-        self.d_vol_data = parray.zeros(self.queue, vol_shape, dtype=self.dtype)
-        self.d_ctr = parray.zeros(self.queue, self.shape, dtype=np.int32) # uint ?
-        self.d_res_int = parray.zeros(self.queue, self.nframes, dtype=np.int32)
-        self._old_d_vol_times = None
-        self._old_d_vol_data = None
-        self._old_d_ctr = None
-        self.d_sums = parray.zeros(self.queue, self.nframes, np.uint32)
-        self.d_res = parray.zeros(self.queue, self.nframes, np.float32)
+    def _allocate_events_arrays(self, is_reallocating=False):
+        tot_nnz = self._events_count
+
+        self.d_vol_times = parray.zeros(self.queue, tot_nnz, dtype=np.int32)
+        self.d_vol_data = parray.zeros(self.queue, tot_nnz, dtype=self.dtype)
+        self.d_offsets = parray.zeros(self.queue, np.prod(self.shape)+1, dtype=np.uint32)
+
+        if not(is_reallocating):
+            self.d_res_int = parray.zeros(self.queue, self.nframes, dtype=np.int32)
+            self.d_sums = parray.zeros(self.queue, self.nframes, np.uint32)
+            self.d_res = parray.zeros(self.queue, self.nframes, np.float32)
 
 
-    def correlate(self, vol_times, vol_data, ctr):
+    def _check_event_arrays(self, vol_times, vol_data, offsets):
+        for arr in [vol_times, vol_data, offsets]:
+            assert arr.ndim == 1
+        assert vol_times.size == vol_data.size
+        assert offsets.size == np.prod(self.shape) + 1
+        numels = vol_data.size
+        if numels > self._events_count:
+            if self.allow_reallocate:
+                self._events_count = numels
+                self._allocate_events_arrays(is_reallocating=True)
+            else:
+                raise ValueError("Too many events and allow_reallocate was set to False")
+
+
+    def correlate(self, vol_times, vol_data, offsets):
+        self._check_event_arrays(vol_times, vol_data, offsets)
         self._set_data({
             "vol_times": vol_times,
             "vol_data": vol_data,
-            "ctr": ctr
+            "offsets": offsets
         })
 
         evt = self.correlation_kernel(
@@ -74,7 +106,7 @@ class EventCorrelator(OpenclCorrelator):
             self.wg,
             self.d_vol_times.data,
             self.d_vol_data.data,
-            self.d_ctr.data,
+            self.d_offsets.data,
             self.d_res_int.data,
             self.d_sums.data,
             np.int32(self.nframes)
@@ -95,38 +127,75 @@ class EventCorrelator(OpenclCorrelator):
         self.profile_add(evt, "Normalization")
 
         self._reset_arrays(["d_vol_times", "d_vol_data", "d_ctr"])
-        
+
         return self.d_res.get()
 
 
-    def build_events_volume(self, frames):
+
+
+    @staticmethod
+    def build_events_structure(frames):
         """
-        Helper function to build a
-        from a stack of (uncompressed) frames.
+        Helper function to build the events data structure from a stack of frames.
+        It returns a tuple (data, times, offsets).
         """
-        max_events = self.max_events_count
-        dtype = self.dtype
+        assert frames.ndim == 3
+        framesT = np.moveaxis(frames, 0, -1)
+        times = np.arange(frames.shape[0], dtype=np.int32)
+        nnz_indices = np.where(framesT > 0)
 
-        frame_shape = frames.shape[1:]
-        n_frames = frames.shape[0]
+        res_data = framesT[nnz_indices]
+        res_times = times[nnz_indices[-1]]
 
-        vol_shape = frame_shape + (max_events, )
-        volume_times = np.zeros(vol_shape, dtype=np.int32)
-        volume_data = np.zeros(vol_shape, dtype=dtype)
-        ctr = np.zeros(frame_shape, dtype=np.int32)
+        offsets = np.unique(np.cumsum((framesT > 0).sum(axis=-1).ravel()))
+        res_offsets = np.ascontiguousarray(offsets, dtype=np.uint32)
 
-        rows, cols = np.indices(frame_shape)
+        return res_data, res_times, res_offsets
 
-        for i in range(n_frames):
-            frame = frames[i]
-            mask = frame > 0
 
-            R = rows[mask]
-            C = cols[mask]
-            depth_pos = ctr[R, C]
-            volume_times[R, C, depth_pos] = i
-            volume_data[R, C, depth_pos] = frame[mask]
-            ctr[R, C] += 1
 
-        return volume_times, volume_data, ctr
 
+
+
+
+"""
+Let `frames` be a stack of `Nt` frames, each of them having `Nx * Ny` pixels.
+
+At each location `(x, y)` in the frame space, we can extract a 1D array
+of `Nt` elements (i.e `frames[:, y, x]`).
+In this array, many elements will be zero, so it is not useful to store them.
+
+The non-zero elements are compacted, along with their "time" index
+in the original frames volume (i.e their indices along axis 0 in the volume space).
+Schematically:
+[0 0 ...     0   p1  0 ...  0   p2 0 ... 0 p3 0 ...] # pixels values
+[0 1 ... (i1-1)  i1 .... (i2-1) i2 0 ... 0 i3 0 ...] # indices values
+gives once compacted:
+[p1 p2 p3 ...] # (nonzero) pixel values
+[i1 i2 i3 ...] # corresponding "time" locations
+
+This is done for each pixel location (x, y). Therefore, for each pixel in the
+frame space (there are Nx*Ny such pixels), we build two arrays E(x, y) and T(x, y)
+containing respectively the compacted non-zero elements, and their time indices.
+
+ -----------
+|      []   |  at location (x, y)   --> (E(x, y), T(x, y)) = ([p1, p2, ...], [t1, t2, ...])
+|           |
+|           |
+ -----------
+
+[ E(0, 0) | E(0, 1) | ... | E(x, y) | ... | E(Ny-1, Nx-1) ] # concatenated nonzero data values
+[ T(0, 0) | T(0, 1) | ... | T(x, y) | ... | T(Ny-1, Nx-1) ] # concatenated corresponding time indices
+
+In order to access the correct arrays E(x, y) and T(x, y) given a coordinate (x, y),
+we need some mapping. This is done by building an "offset" array "L":
+
+[L0 = 0   | L1      | ... | L(x, y) | ... ] # offsets
+[ E(0, 0) | E(0, 1) | ... | E(x, y) | ... | E(Ny-1, Nx-1) ] # concatenated nonzero data values
+
+The offset to access E(0, 0) is 0.
+The offset to access E(0, 1) is 0 + <number of non-zero pixels in E(0 0)>,
+and so on.
+
+
+"""

--- a/dynamix/correlator/test/test_dense.py
+++ b/dynamix/correlator/test/test_dense.py
@@ -94,7 +94,7 @@ class TestDense(unittest.TestCase):
                 "%s: something wrong in bin index %d" % (method_name, bin_idx)
             )
 
-    def notused_test_dense_correlator(self):
+    def test_dense_correlator(self):
         self.correlator = DenseCorrelator(
             self.shape,
             self.nframes,

--- a/dynamix/correlator/test/test_dense.py
+++ b/dynamix/correlator/test/test_dense.py
@@ -36,7 +36,8 @@ import logging
 import unittest
 import numpy as np
 from dynamix.test.utils import XPCSDataset
-from dynamix.correlator.dense import DenseCorrelator, py_dense_correlator, FFTWCorrelator, MatMulCorrelator, CublasMatMulCorrelator
+from dynamix.correlator.dense import DenseCorrelator, py_dense_correlator, FFTWCorrelator, MatMulCorrelator
+from dynamix.correlator.cuda import CublasMatMulCorrelator, CUFFTCorrelator
 
 # logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/dynamix/correlator/test/test_dense.py
+++ b/dynamix/correlator/test/test_dense.py
@@ -37,7 +37,7 @@ import unittest
 import numpy as np
 from dynamix.test.utils import XPCSDataset
 from dynamix.correlator.dense import DenseCorrelator, py_dense_correlator, FFTWCorrelator, MatMulCorrelator
-from dynamix.correlator.cuda import CublasMatMulCorrelator, CUFFTCorrelator
+from dynamix.correlator.cuda import CublasMatMulCorrelator, CUFFTCorrelator, CUFFT
 
 # logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -47,6 +47,7 @@ try:
     import pyfftw
 except ImportError:
     pyfftw = None
+
 
 
 class TestDense(unittest.TestCase):
@@ -145,6 +146,25 @@ class TestDense(unittest.TestCase):
         res = self.fftcorrelator.correlate(self.dataset.data)
         logger.info("FFTw dense correlator took %.1f ms" % ((time() - t0)*1e3))
         self.compare(res, "FFTw dense correlator")
+
+
+    def test_cufft_dense_correlator(self):
+        if CUFFT is None:
+            self.skipTest("Need pycuda scikit-cuda")
+        self.fftcorrelator = CUFFTCorrelator(
+            self.shape,
+            self.nframes,
+            qmask=self.dataset.qmask,
+            extra_options={"save_fft_plans": False}
+        )
+        t0 = time()
+        res = self.fftcorrelator.correlate(self.dataset.data)
+        logger.info("CUFFT dense correlator took %.1f ms" % ((time() - t0)*1e3))
+        self.compare(res, "CUFFT dense correlator")
+
+
+
+
 
 
 def suite():

--- a/dynamix/correlator/test/test_dense.py
+++ b/dynamix/correlator/test/test_dense.py
@@ -36,10 +36,11 @@ import logging
 import unittest
 import numpy as np
 from dynamix.test.utils import XPCSDataset
-from dynamix.correlator.dense import DenseCorrelator, py_dense_correlator, CUFFT, DenseCuFFTCorrelator, pyfftw, DenseFFTwCorrelator
+from dynamix.correlator.dense import DenseCorrelator, py_dense_correlator, CUFFT, DenseCuFFTCorrelator, pyfftw, DenseFFTwCorrelator, MatMulCorrelator, CublasMatMulCorrelator
 
 # logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 if CUFFT is not None:
@@ -50,44 +51,50 @@ class TestDense(unittest.TestCase):
 
     ref = None
 
-    def setUp(self):
+    @classmethod
+    def load_data(cls):
         logger.debug("Loading data")
-        self.dataset = XPCSDataset("eiger_514_10k")
-        logger.setLevel(logging.DEBUG)
-        self.shape = self.dataset.dataset_desc.frame_shape
-        self.nframes = self.dataset.dataset_desc.nframes
+        cls.dataset = XPCSDataset("eiger_514_10k")
+        cls.shape = cls.dataset.dataset_desc.frame_shape
+        cls.nframes = cls.dataset.dataset_desc.nframes
+
+    @classmethod
+    def compute_reference_correlation(cls):
+        if cls.ref is not None:
+            return # dont re-compute ref
+        t0 = time()
+        ref = np.zeros(
+            (cls.dataset.dataset_desc.bins, cls.dataset.dataset_desc.nframes),
+            dtype=np.float32
+        )
+        for bin_val in range(1, cls.dataset.dataset_desc.bins+1):
+            mask = (cls.dataset.qmask == bin_val)
+            ref[bin_val-1] = py_dense_correlator(cls.dataset.data, mask)
+        logger.info("Numpy dense correlator took %.1f ms" % ((time() - t0)*1e3))
+        cls.ref = ref
+
+    @classmethod
+    def setUpClass(cls):
+        cls.load_data()
+        cls.compute_reference_correlation()
+
+    def setUp(self):
         self.tol = 5e-3
-        self.compute_reference_correlation()
+
 
     def tearDown(self):
         pass
 
-    def compute_reference_correlation(self):
-        if self.ref is not None:
-            return # dont re-compute ref
-        t0 = time()
-        ref = np.zeros(
-            (self.dataset.dataset_desc.bins, self.dataset.dataset_desc.nframes -1),
-            dtype=np.float32
-        )
-        for bin_val in range(1, self.dataset.dataset_desc.bins+1):
-            mask = (self.dataset.qmask == bin_val)
-            ref[bin_val-1] = py_dense_correlator(self.dataset.data, mask)
-        logger.info("Numpy dense correlator took %.1f ms" % ((time() - t0)*1e3))
-        self.ref = ref
-
-
     def compare(self, res, method_name):
-        errors = res[:, 1:] - self.ref
+        errors = res - self.ref
         errors_max = np.max(np.abs(errors), axis=1)
-
         for bin_idx in range(errors_max.shape[0]):
             self.assertLess(
                 errors_max[bin_idx], self.tol,
                 "%s: something wrong in bin index %d" % (method_name, bin_idx)
             )
 
-    def test_dense_correlator(self):
+    def notused_test_dense_correlator(self):
         self.correlator = DenseCorrelator(
             self.shape,
             self.nframes,
@@ -101,6 +108,27 @@ class TestDense(unittest.TestCase):
         )
         logger.info("OpenCL dense correlator took %.1f ms" % ((time() - t0)*1e3))
         self.compare(res, "OpenCL dense correlator")
+
+
+    def test_matmul_correlator(self):
+        correlator = MatMulCorrelator(
+            self.shape, self.nframes, self.dataset.qmask
+        )
+        t0 = time()
+        res = correlator.correlate(self.dataset.data)
+        logger.info("Matmul correlator took %.1f ms" % ((time() - t0)*1e3))
+        self.compare(res, "Matmul correlator")
+
+
+    def test_cuda_matmul_correlator(self):
+        correlator = CublasMatMulCorrelator(
+            self.shape, self.nframes, self.dataset.qmask
+        )
+        t0 = time()
+        res = correlator.correlate(self.dataset.data)
+        logger.info("Cublas Matmul correlator took %.1f ms" % ((time() - t0)*1e3))
+        self.compare(res, "Cublas Matmul correlator")
+
 
     def test_cufft_dense_correlator(self):
         if not(CUFFT):

--- a/dynamix/correlator/test/test_event.py
+++ b/dynamix/correlator/test/test_event.py
@@ -1,0 +1,139 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2019-2019 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""tests for the event correlator.
+
+"""
+
+__authors__ = ["P. Paleo"]
+__license__ = "MIT"
+__date__ = "04/09/2019"
+
+
+from time import time
+import logging
+import unittest
+import numpy as np
+from dynamix.test.utils import XPCSDataset
+from dynamix.correlator.event import EventCorrelator, FramesCompressor
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+
+class TestEventDataStructure(unittest.TestCase):
+
+    def setUp(self):
+        logger.debug("Loading data")
+        self.dataset = XPCSDataset("andor_1024_3k")
+        self.shape = self.dataset.dataset_desc.frame_shape
+        self.nframes = self.dataset.dataset_desc.nframes
+        self.compressor = FramesCompressor(self.shape, self.nframes, 330, np.int8)
+
+    def tearDown(self):
+        pass
+
+    def compute_reference_datastructure(self):
+        logger.debug("Computing reference data compaction to events")
+        return self.compressor.compress_all_stack(self.dataset.data)
+
+
+    def test_progressive_compression(self):
+        # Simulate progressive acquisition + compaction of frames
+        logger.debug("Computing progressive data compaction")
+        for frame in self.dataset.data:
+            self.compressor.process_frame(frame)
+        # Compare with reference implementation (compact all frames in a single pass)
+        ref_data, ref_times, ref_offsets = self.compute_reference_datastructure()
+        data, times, offsets = self.compressor.get_compacted_events()
+
+        self.assertTrue(np.allclose(data, ref_data))
+        self.assertTrue(np.allclose(times, ref_times))
+        self.assertTrue(np.allclose(offsets, ref_offsets))
+
+
+class TestEvent(unittest.TestCase):
+
+    ref = None
+
+    def setUp(self):
+        logger.debug("Loading data")
+        self.dataset = XPCSDataset("andor_1024_10k")
+        self.shape = self.dataset.dataset_desc.frame_shape
+        self.nframes = self.dataset.dataset_desc.nframes
+        self.ref = self.dataset.result
+        self.tol = 5e-3
+
+    def tearDown(self):
+        pass
+
+
+    def compare(self, res, method_name):
+        errors = res[:, 1:] - self.ref
+        errors_max = np.max(np.abs(errors), axis=1)
+
+        for bin_idx in range(errors_max.shape[0]):
+            self.assertLess(
+                errors_max[bin_idx], self.tol,
+                "%s: something wrong in bin index %d" % (method_name, bin_idx)
+            )
+
+    def test_event_correlator(self):
+        # Init correlator
+        self.correlator = EventCorrelator(
+            self.shape,
+            self.nframes,
+            dtype=self.dataset.dataset_desc.dtype,
+            max_events_count=330,
+            scale_factor=1025171, # number of pixels actually used
+            profile=True
+        )
+        # Build events data structure
+        vol_data, vol_times, offsets = self.correlator.build_events_structure(
+            self.dataset.data
+        )
+        # Correlate
+        t0 = time()
+        res = self.correlator.correlate(
+            vol_times,
+            vol_data,
+            offsets
+        )
+        logger.info("OpenCL dense correlator took %.1f ms" % ((time() - t0)*1e3))
+        self.compare(res, "OpenCL dense correlator")
+
+
+
+def suite():
+    testsuite = unittest.TestSuite()
+    testsuite.addTest(
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestEventDataStructure)
+        # unittest.defaultTestLoader.loadTestsFromTestCase(TestEvent)
+    )
+    return testsuite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest="suite")
+

--- a/dynamix/resources/opencl/densecorrelator.cl
+++ b/dynamix/resources/opencl/densecorrelator.cl
@@ -6,7 +6,6 @@
 kernel void correlator_multiQ_dense(
     const global char* frames,
     const global int* q_mask,
-    const global float* norm_mask,
     const global float* normalization,
     global float* output,
     int image_height,

--- a/dynamix/resources/opencl/evtcorrelator.cl
+++ b/dynamix/resources/opencl/evtcorrelator.cl
@@ -72,6 +72,6 @@ kernel void normalize_correlation(
         corr += (my_sum[t] * my_sum[t - tau]);
     }
     corr /= scale_factors[bin_idx]; // passing 1/scale_factor in preprocessor is not numerically accurate
-    res[bin_idx + Nt + tau] = res_int[bin_idx*Nt + tau] / corr;
+    res[bin_idx * Nt + tau] = res_int[bin_idx*Nt + tau] / corr;
 }
 

--- a/dynamix/resources/opencl/evtcorrelator.cl
+++ b/dynamix/resources/opencl/evtcorrelator.cl
@@ -1,4 +1,5 @@
-// Launched with (image_width, image_width) grid of threads.
+// Launched with (image_width, image_height) grid of threads.
+// One thread handle one line of events, so threads are indexes by frame pixel indices.
 kernel void event_correlator_oneQ(
     const global int* vol_times_array,
     const global DTYPE* vol_data_array,

--- a/dynamix/resources/opencl/evtcorrelator.cl
+++ b/dynamix/resources/opencl/evtcorrelator.cl
@@ -21,11 +21,11 @@ kernel void event_correlator_oneQ(
     global DTYPE* vol_data = vol_data_array + offset;
 
     // Fetch vol_XXX[y, x, :] in fast memory
-    int times[MAX_EVT_COUNT];
-    DTYPE data[MAX_EVT_COUNT];
+    int times[MAX_EVT_COUNT] = {0};
+    DTYPE data[MAX_EVT_COUNT] = {0};
     for (int i = 0; i < n_events; i++) {
-        times[i] = vol_times[pos*MAX_EVT_COUNT+i];
-        data[i] = vol_data[pos*MAX_EVT_COUNT+i];
+        times[i] = vol_times[i];
+        data[i] = vol_data[i];
     }
 
     // Compute r(p, t, t-tau)
@@ -42,49 +42,6 @@ kernel void event_correlator_oneQ(
 
 
 
-
-
-
-// "Event correlator"
-// One thread : r(p, (t, t-tau)) -> atomic_add
-
-kernel void event_correlator_oneQ_simple(
-    const global int* vol_times,
-    const global DTYPE* vol_data,
-    const global int* ctr,
-    global int* res_tau,
-    global uint* sums,
-    int image_height
-) {
-    uint x = get_global_id(0);
-    uint y = get_global_id(1);
-
-    if ((x >= IMAGE_WIDTH) || (y >= image_height)) return;
-
-    uint pos = y*IMAGE_WIDTH + x;
-    int n_events = ctr[pos];
-    if (n_events == 0) return;
-
-
-    // Fetch vol_XXX[y, x, :] in fast memory
-    // TODO investigate registers usage
-    int times[MAX_EVT_COUNT];
-    DTYPE data[MAX_EVT_COUNT];
-    for (int i = 0; i < n_events; i++) {
-        times[i] = vol_times[pos*MAX_EVT_COUNT+i];
-        data[i] = vol_data[pos*MAX_EVT_COUNT+i];
-    }
-
-    // Compute r(p, t, t-tau)
-    DTYPE sum = 0;
-    for (int i_tau = 0; i_tau < n_events; i_tau++) {
-        atomic_add(sums + times[i_tau], data[i_tau]);
-        for (int i_t = i_tau; i_t < n_events; i_t++) {
-            int tau = times[i_t] - times[i_t - i_tau];
-            atomic_add(res_tau + tau, data[i_t] * data[i_t - i_tau]);
-        }
-    }
-}
 
 
 #ifndef SCALE_FACTOR
@@ -104,8 +61,9 @@ kernel void normalize_correlation_oneQ(
     if (tau >= Nt) return;
     float s = 0.0f;
     for (int t = tau; t < Nt; t++) {
-        s += (sums[t] * sums[t - tau]) * SCALE_FACTOR;
+        s += (sums[t] * sums[t - tau]);
     }
+    s /= SCALE_FACTOR;
     res[tau] = res_int[tau] / s;
 }
 

--- a/dynamix/resources/opencl/evtcorrelator.cl
+++ b/dynamix/resources/opencl/evtcorrelator.cl
@@ -1,8 +1,54 @@
+// Launched with (image_width, image_width) grid of threads.
+kernel void event_correlator_oneQ(
+    const global int* vol_times_array,
+    const global DTYPE* vol_data_array,
+    const global uint* offsets,
+    global int* res_tau,
+    global uint* sums,
+    int image_height
+) {
+    uint x = get_global_id(0);
+    uint y = get_global_id(1);
+
+    if ((x >= IMAGE_WIDTH) || (y >= image_height)) return;
+
+    uint pos = y*IMAGE_WIDTH + x;
+    uint offset = offsets[pos];
+    int n_events = offsets[pos+1] - offset;
+    if (n_events == 0) return;
+
+    global int* vol_times = vol_times_array + offset;
+    global DTYPE* vol_data = vol_data_array + offset;
+
+    // Fetch vol_XXX[y, x, :] in fast memory
+    int times[MAX_EVT_COUNT];
+    DTYPE data[MAX_EVT_COUNT];
+    for (int i = 0; i < n_events; i++) {
+        times[i] = vol_times[pos*MAX_EVT_COUNT+i];
+        data[i] = vol_data[pos*MAX_EVT_COUNT+i];
+    }
+
+    // Compute r(p, t, t-tau)
+    DTYPE sum = 0;
+    for (int i_tau = 0; i_tau < n_events; i_tau++) {
+        atomic_add(sums + times[i_tau], data[i_tau]);
+        for (int i_t = i_tau; i_t < n_events; i_t++) {
+            int tau = times[i_t] - times[i_t - i_tau];
+            atomic_add(res_tau + tau, data[i_t] * data[i_t - i_tau]);
+        }
+    }
+}
+
+
+
+
+
+
+
 // "Event correlator"
 // One thread : r(p, (t, t-tau)) -> atomic_add
 
-
-kernel void event_correlator_oneQ(
+kernel void event_correlator_oneQ_simple(
     const global int* vol_times,
     const global DTYPE* vol_data,
     const global int* ctr,

--- a/dynamix/test/utils.py
+++ b/dynamix/test/utils.py
@@ -73,7 +73,7 @@ dataset_eiger_20k = DatasetDescription(
     bins=None,
 )
 
-dataset_al_600 =DatasetDescription(
+dataset_al_600 = DatasetDescription(
     name="Al_512_600",
     data="Al_600.npz",
     result="unknown.npz",
@@ -85,7 +85,7 @@ dataset_al_600 =DatasetDescription(
     frame_shape=(512, 512),
     dtype=np.uint32,
     bins=None,
-) 
+)
 
 def get_datasets():
     datasets = [dataset_andor_10k, dataset_andor_3k, dataset_eiger_10k, dataset_eiger_20k, dataset_al_600]

--- a/dynamix/test/utils.py
+++ b/dynamix/test/utils.py
@@ -31,7 +31,7 @@ dataset_andor_10k = DatasetDescription(
 )
 
 dataset_andor_3k = DatasetDescription(
-    name="andor_1024_10k",
+    name="andor_1024_3k",
     data="Fe79_Andor_3000.npz",
     result="wcf_Fe79_ramp1_240C_down_1_3000_raw.npz",
     description="""

--- a/dynamix/utils.py
+++ b/dynamix/utils.py
@@ -58,3 +58,4 @@ def get_next_power(n, powers=None):
     if powers[idx-1] == n:
         return n
     return powers[idx]
+

--- a/dynamix/utils.py
+++ b/dynamix/utils.py
@@ -17,6 +17,11 @@ def nextpow2(n):
         p *= 2
     return p
 
+def updiv(a, b):
+    """
+    return the integer division, plus one if `a` is not a multiple of `b`
+    """
+    return (a + (b - 1)) // b
 
 def estimate_r2c_memory(fft_shape):
     """

--- a/dynamix/utils.py
+++ b/dynamix/utils.py
@@ -1,3 +1,5 @@
+from itertools import product
+from bisect import bisect
 import os
 import numpy as np
 
@@ -23,11 +25,36 @@ def updiv(a, b):
     """
     return (a + (b - 1)) // b
 
-def estimate_r2c_memory(fft_shape):
+
+def generate_powers():
     """
-    Estimate the memory (in MB) taken by a R2C (FFT, IFFT) plan couple,
-    assuming float32 -> complex64 dtypes.
+    Generate a list of powers of [2, 3, 5, 7],
+    up to (2**15)*(3**9)*(5**6)*(7**5).
     """
-    real_bytes = np.prod(fft_shape)*4
-    cplx_bytes = (np.prod(fft_shape[:-1]) * (fft_shape[-1]//2+1))*8
-    return (real_bytes + cplx_bytes)*2/1e6
+    primes = [2, 3, 5, 7]
+    maxpow = {2: 15, 3: 9, 5: 6, 7: 5}
+    valuations = []
+    for prime in primes:
+        # disallow any odd number (for R2C transform), and any number
+        # not multiple of 4 (Ram-Lak filter behaves strangely when
+        # dwidth_padded/2 is not even)
+        minval = 2 if prime == 2 else 0
+        valuations.append(range(minval, maxpow[prime]+1))
+    powers = product(*valuations)
+    res = []
+    for pw in powers:
+        res.append(np.prod(list(map(lambda x : x[0]**x[1], zip(primes, pw)))))
+    return np.unique(res)
+
+
+def get_next_power(n, powers=None):
+    """
+    Given a number, get the closest (upper) number p such that
+    p is a power of 2, 3, 5 and 7.
+    """
+    if powers is None:
+        powers = generate_powers()
+    idx = bisect(powers, n)
+    if powers[idx-1] == n:
+        return n
+    return powers[idx]


### PR DESCRIPTION
:warning: #7  should be merged beforehand.

This PR brings various implementations of XPCS correlation function for "dense" XPCS data:
  - [x] Outer product, numpy backend: `MatMulCorrelator`
  - [x] Outer product, CUDA/cublas backend: `CublasMatMulCorrelator`
  - [x] FFT, FFTW backend
  - [x] FFT, CUFFT backend
  - [x] A general-purpose OpenCL dense correlator : `DenseCorrelator`

From what I tested, OpenCL `clfft` is not efficient enough (with respect to `numpy` which already leverages all CPU cores for the outer product) to bother implementing a "`ClblasMatMulCorrelator`".

It is likely that `DenseCorrelator` will be removed in the future, as it is slower that any other implementation.